### PR TITLE
LIBITD-2455. Updated tests and logging

### DIFF
--- a/src/core/gateway.py
+++ b/src/core/gateway.py
@@ -12,8 +12,8 @@ logger = create_logger(__name__)
 class HttpGateway:
     @staticmethod
     def _parse_error(content):
-        if content is None:
-            logger.warning('Failed to retreive xml from Alma API')
+        if content == '':
+            logger.warning('Failed to retrieve xml from Alma API')
             return
 
         soup = BeautifulSoup(content, features='xml')
@@ -28,7 +28,7 @@ class HttpGateway:
                 error_code = error.find('errorCode').text
                 error_message = error.find('errorMessage').text
             except AttributeError:
-                logger.warning('Failed to retrieve error code and message in content')
+                logger.warning('Failed to retrieve error code and/or message in content')
                 return
 
             logger.warning(f'Alma API error {error_code}: {error_message}')
@@ -43,7 +43,9 @@ class HttpGateway:
 
         if r.status_code == 400:
             logger.warning(f"Received {r.status_code} from '{url}' in {request_response_time}")
-            HttpGateway._parse_error(r.content)
+
+            error_content = r.content.decode('UTF-8') if r.content else ''
+            HttpGateway._parse_error(error_content)
             abort(r.status_code, 'Received 400 from the Alma API')
 
         if r.status_code == 500:

--- a/tests/core/gateway_test.py
+++ b/tests/core/gateway_test.py
@@ -4,26 +4,26 @@ from werkzeug.exceptions import BadGateway, BadRequest, GatewayTimeout, Internal
 
 
 def test_200_response_from_server(requests_mock, caplog):
-    requests_mock.get('http://test.com', text='Application OK', status_code=200)
-    response = HttpGateway.get('http://test.com', {})
+    requests_mock.get('http://example.com', text='Application OK', status_code=200)
+    response = HttpGateway.get('http://example.com', {})
     assert 'Application OK' == response.decode('UTF-8')
     assert 'Received 200' in caplog.text
 
 
 def test_400_response_from_server(requests_mock, caplog):
-    requests_mock.get('http://test.com', text='Bad Request', status_code=400)
+    requests_mock.get('http://example.com', text='Bad Request', status_code=400)
     with pytest.raises(BadRequest):
-        HttpGateway.get('http://test.com', {})
+        HttpGateway.get('http://example.com', {})
 
     assert 'Received 400' in caplog.text
     assert 'Failed to find errors in content' in caplog.text
 
 
 def test_400_xml_no_content_from_server(requests_mock, caplog):
-    requests_mock.get('http://test.com', text='', status_code=400)
+    requests_mock.get('http://example.com', text='', status_code=400)
 
     with pytest.raises(BadRequest):
-        HttpGateway.get('http://test.com', {})
+        HttpGateway.get('http://example.com', {})
 
     assert 'Received 400' in caplog.text
     assert 'Failed to retrieve xml from Alma API' in caplog.text
@@ -42,10 +42,10 @@ def test_400_xml_no_error_code_from_server(requests_mock, caplog):
     </web_service_result>
     """
 
-    requests_mock.get('http://test.com', text=xml_error_response_no_error_code, status_code=400)
+    requests_mock.get('http://example.com', text=xml_error_response_no_error_code, status_code=400)
 
     with pytest.raises(BadRequest):
-        HttpGateway.get('http://test.com', {})
+        HttpGateway.get('http://example.com', {})
 
     assert 'Received 400' in caplog.text
     assert 'Failed to retrieve error code and/or message in content' in caplog.text
@@ -64,10 +64,10 @@ def test_400_xml_no_error_message_from_server(requests_mock, caplog):
     </web_service_result>
     """
 
-    requests_mock.get('http://test.com', text=xml_error_response_no_error_code, status_code=400)
+    requests_mock.get('http://example.com', text=xml_error_response_no_error_code, status_code=400)
 
     with pytest.raises(BadRequest):
-        HttpGateway.get('http://test.com', {})
+        HttpGateway.get('http://example.com', {})
 
     assert 'Received 400' in caplog.text
     assert 'Failed to retrieve error code and/or message in content' in caplog.text
@@ -87,50 +87,50 @@ def test_400_xml_error_response_from_server(requests_mock, caplog):
     </web_service_result>
     """
 
-    requests_mock.get('http://test.com', text=xml_error_response, status_code=400)
+    requests_mock.get('http://example.com', text=xml_error_response, status_code=400)
 
     with pytest.raises(BadRequest):
-        HttpGateway.get('http://test.com', {})
+        HttpGateway.get('http://example.com', {})
 
     assert 'Received 400' in caplog.text
     assert 'Alma API error 402204: Input parameters mmsId adsf is not numeric.' in caplog.text
 
 
 def test_404_response_from_server(requests_mock, caplog):
-    requests_mock.get('http://test.com', text='Not Found', status_code=404)
+    requests_mock.get('http://example.com', text='Not Found', status_code=404)
     with pytest.raises(NotFound):
-        HttpGateway.get('http://test.com', {})
+        HttpGateway.get('http://example.com', {})
 
     assert 'Received unexpected 404' in caplog.text
 
 
 def test_429_response_from_server(requests_mock, caplog):
-    requests_mock.get('http://test.com', text='Too Many Requests', status_code=429)
+    requests_mock.get('http://example.com', text='Too Many Requests', status_code=429)
     with pytest.raises(TooManyRequests):
-        HttpGateway.get('http://test.com', {})
+        HttpGateway.get('http://example.com', {})
 
     assert 'Received unexpected 429' in caplog.text
 
 
 def test_500_response_from_server(requests_mock, caplog):
-    requests_mock.get('http://test.com', text='', status_code=500)
+    requests_mock.get('http://example.com', text='', status_code=500)
     with pytest.raises(InternalServerError):
-        HttpGateway.get('http://test.com', {})
+        HttpGateway.get('http://example.com', {})
 
     assert 'Received 500' in caplog.text
 
 
 def test_502_response_from_server(requests_mock, caplog):
-    requests_mock.get('http://test.com', text='Bad Gateway', status_code=502)
+    requests_mock.get('http://example.com', text='Bad Gateway', status_code=502)
     with pytest.raises(BadGateway):
-        HttpGateway.get('http://test.com', {})
+        HttpGateway.get('http://example.com', {})
 
     assert 'Received unexpected 502' in caplog.text
 
 
 def test_504_response_from_server(requests_mock, caplog):
-    requests_mock.get('http://test.com', text='Gateway Timeout', status_code=504)
+    requests_mock.get('http://example.com', text='Gateway Timeout', status_code=504)
     with pytest.raises(GatewayTimeout):
-        HttpGateway.get('http://test.com', {})
+        HttpGateway.get('http://example.com', {})
 
     assert 'Received unexpected 504' in caplog.text

--- a/tests/core/gateway_test.py
+++ b/tests/core/gateway_test.py
@@ -101,7 +101,7 @@ def test_404_response_from_server(requests_mock, caplog):
     with pytest.raises(NotFound):
         HttpGateway.get('http://example.com', {})
 
-    assert 'Received unexpected 404' in caplog.text
+    assert 'Received 404' in caplog.text
 
 
 def test_429_response_from_server(requests_mock, caplog):
@@ -109,7 +109,7 @@ def test_429_response_from_server(requests_mock, caplog):
     with pytest.raises(TooManyRequests):
         HttpGateway.get('http://example.com', {})
 
-    assert 'Received unexpected 429' in caplog.text
+    assert 'Received 429' in caplog.text
 
 
 def test_500_response_from_server(requests_mock, caplog):
@@ -125,7 +125,7 @@ def test_502_response_from_server(requests_mock, caplog):
     with pytest.raises(BadGateway):
         HttpGateway.get('http://example.com', {})
 
-    assert 'Received unexpected 502' in caplog.text
+    assert 'Received 502' in caplog.text
 
 
 def test_504_response_from_server(requests_mock, caplog):
@@ -133,4 +133,4 @@ def test_504_response_from_server(requests_mock, caplog):
     with pytest.raises(GatewayTimeout):
         HttpGateway.get('http://example.com', {})
 
-    assert 'Received unexpected 504' in caplog.text
+    assert 'Received 504' in caplog.text

--- a/tests/textbooks/processor_test.py
+++ b/tests/textbooks/processor_test.py
@@ -17,9 +17,9 @@ def test_unique_mms_ids():
 
 def test_retrieve_bibs_item_available(requests_mock):
     xml_response = resource_file_as_string('tests/resources/retrieve_bibs_200_response_available.xml')
-    requests_mock.get('http://test.com/test_endpoint', text=xml_response, status_code=200)
+    requests_mock.get('http://example.com/test_endpoint', text=xml_response, status_code=200)
 
-    mock_config = {'host': 'http://test.com', 'endpoint': '/test_endpoint'}
+    mock_config = {'host': 'http://example.com', 'endpoint': '/test_endpoint'}
     processor = TopTextbooksProcessor(AlmaServerGateway(mock_config))
 
     mock_request = ["990008536900108238"]


### PR DESCRIPTION
* Updated some failing tests, and added additional tests to verify handling of Alma error code and message when a HTTP 400 error is returned.

* Replaced "test.com" host in tests with "example.com"

    The "example.com" domain is designed for use in test/example codes.
    While the mock requests where "test.com" in used shouldn't ever make
    actual HTTP calls, it seems reasonable to replace with "example.com",
    which is the more correct host for that purpose.

* Added status code/response time parameters to JSON logging

    For logging HTTP responses, added "http_status_code" and
    "request_response_time_in_secs" parameters to the JSON logging output.

    This should enable the HTTP responses (with response times) to be more
    easily retrievable from the Splunk log.

https://umd-dit.atlassian.net/browse/LIBITD-2455